### PR TITLE
Find merchant

### DIFF
--- a/app/controllers/api/v1/item_merchants_controller.rb
+++ b/app/controllers/api/v1/item_merchants_controller.rb
@@ -4,7 +4,7 @@ class Api::V1::ItemMerchantsController < ApplicationController
       item = Item.find(params[:item_id])
       render json: MerchantSerializer.single_merchant(item.merchant)
     else
-      render json: MerchantSerializer.no_merchant, status: :not_found
+      render json: MerchantSerializer.no_merchant(404), status: :not_found
     end
   end
 end

--- a/app/controllers/api/v1/merchants/search_controller.rb
+++ b/app/controllers/api/v1/merchants/search_controller.rb
@@ -1,0 +1,21 @@
+class Api::V1::Merchants::SearchController < ApplicationController 
+
+  def show
+    if search_params[:name].present?
+      merchant = Merchant.search_names(search_params)
+      if  merchant.nil?
+        render json: MerchantSerializer.no_merchant_found, status: :not_found
+      else
+        render json: MerchantSerializer.single_merchant(merchant)
+      end
+    else
+      render json: MerchantSerializer.no_merchant(400), status: :bad_request
+    end
+  end
+
+  private
+
+  def search_params 
+    params.permit(:name)
+  end
+end

--- a/app/controllers/api/v1/merchants_controller.rb
+++ b/app/controllers/api/v1/merchants_controller.rb
@@ -8,7 +8,7 @@ class Api::V1::MerchantsController < ApplicationController
       merchant = Merchant.find(params[:id])
       render json: MerchantSerializer.single_merchant(merchant)
     else
-      render json: MerchantSerializer.no_merchant, status: :not_found
+      render json: MerchantSerializer.no_merchant(404), status: :not_found
     end
   end
 

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -4,4 +4,9 @@ class Merchant < ApplicationRecord
   has_many :customers, through: :invoices
   has_many :transactions, through: :invoices
   has_many :invoice_items, through: :items
+
+  def self.search_names(search)
+    where("name ILIKE '%#{search[:name]}%'")
+    .order(:name).limit(1).first
+  end
 end

--- a/app/serializers/merchant_serializer.rb
+++ b/app/serializers/merchant_serializer.rb
@@ -25,12 +25,24 @@ class MerchantSerializer
     }
   end
 
-  def self.no_merchant
+  def self.no_merchant(status)
     {
-      status: '404',
+      status: status.to_s,
       error: {
         id: nil,
         type: Merchant.name.downcase
+      }
+    }
+  end
+
+  def self.no_merchant_found
+    {
+      data: {
+        id: nil,
+        type: Merchant.name.downcase,
+        attributes: {
+            name: ''
+          }
       }
     }
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,11 @@ Rails.application.routes.draw do
 
   namespace :api do
     namespace :v1 do
-      resources :merchants, only: %i[index show] do
+      namespace :merchants do 
+        get '/find', to: 'search#show'
+      end
+      
+      resources :merchants, only: [:index, :show] do
         get '/items', to: 'merchant_items#index'
       end
 

--- a/spec/requests/api/v1/merchant/search_request_spec.rb
+++ b/spec/requests/api/v1/merchant/search_request_spec.rb
@@ -1,0 +1,84 @@
+require 'rails_helper'
+
+describe 'Merchant Search API' do
+  describe 'search index' do
+    describe 'happy path' do
+      it 'returns a single merchant based on search params' do
+        merchant_1 = create(:merchant, name: 'Ring World')
+        merchant_2 = create(:merchant, name: 'All the Pretty Rings')
+
+        get '/api/v1/merchants/find?name=ring'
+
+        merchant = JSON.parse(response.body, symbolize_names: true)
+
+        expect(response).to be_successful
+
+        expect(merchant).to have_key(:data)
+        expect(merchant[:data]).to be_a(Hash)
+
+        expect(merchant[:data]).to have_key(:id)
+        expect(merchant[:data][:id]).to be_a(String)
+
+        expect(merchant[:data]).to have_key(:type)
+        expect(merchant[:data][:type]).to be_a(String)
+
+        expect(merchant[:data]).to have_key(:attributes)
+        expect(merchant[:data][:attributes]).to be_a(Hash)
+
+        expect(merchant[:data][:attributes]).to have_key(:name)
+        expect(merchant[:data][:attributes][:name]).to be_a(String)
+      end
+    end
+
+    describe 'sad path' do
+      it 'returns a 404 status code and a empty merchant hash when no merchant is found' do
+        merchant_1 = create(:merchant, name: 'Ring World')
+        merchant_2 = create(:merchant, name: 'All the Pretty Rings')
+
+        get '/api/v1/merchants/find?name=silver'
+
+        merchant = JSON.parse(response.body, symbolize_names: true)
+
+        expect(response).to have_http_status(404)
+
+        expect(merchant).to have_key(:data)
+        expect(merchant[:data]).to be_a(Hash)
+
+        expect(merchant[:data]).to have_key(:id)
+        expect(merchant[:data][:id]).to be(nil)
+
+        expect(merchant[:data]).to have_key(:type)
+        expect(merchant[:data][:type]).to be_a(String)
+
+        expect(merchant[:data]).to have_key(:attributes)
+        expect(merchant[:data][:attributes]).to be_a(Hash)
+
+        expect(merchant[:data][:attributes]).to have_key(:name)
+        expect(merchant[:data][:attributes][:name]).to be_a(String)
+      end
+
+      it 'returns a 400 status code and a merchant error hash when name parameter is empty' do
+        merchant_1 = create(:merchant, name: 'Ring World')
+        merchant_2 = create(:merchant, name: 'All the Pretty Rings')
+
+        get '/api/v1/merchants/find?name='
+
+        merchant = JSON.parse(response.body, symbolize_names: true)
+
+        expect(response).to have_http_status(400)
+
+        expect(merchant).to have_key(:status)
+        expect(merchant[:status]).to be_a(String)
+
+        expect(merchant).to have_key(:error)
+        expect(merchant[:error]).to be_a(Hash)
+
+        expect(merchant[:error]).to have_key(:id)
+        expect(merchant[:error][:id]).to be(nil)
+
+        expect(merchant[:error]).to have_key(:type)
+        expect(merchant[:error][:type]).to be_a(String)
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/merchant/search_request_spec.rb
+++ b/spec/requests/api/v1/merchant/search_request_spec.rb
@@ -79,6 +79,29 @@ describe 'Merchant Search API' do
         expect(merchant[:error]).to have_key(:type)
         expect(merchant[:error][:type]).to be_a(String)
       end
+
+      it 'returns a 400 status code and a merchant error hash when parameter missing' do
+        merchant_1 = create(:merchant, name: 'Ring World')
+        merchant_2 = create(:merchant, name: 'All the Pretty Rings')
+
+        get '/api/v1/merchants/find?'
+
+        merchant = JSON.parse(response.body, symbolize_names: true)
+
+        expect(response).to have_http_status(400)
+
+        expect(merchant).to have_key(:status)
+        expect(merchant[:status]).to be_a(String)
+
+        expect(merchant).to have_key(:error)
+        expect(merchant[:error]).to be_a(Hash)
+
+        expect(merchant[:error]).to have_key(:id)
+        expect(merchant[:error][:id]).to be(nil)
+
+        expect(merchant[:error]).to have_key(:type)
+        expect(merchant[:error][:type]).to be_a(String)
+      end
     end
   end
 end


### PR DESCRIPTION
Returns a single merchant object, if found

- returns the first merchant in the database in case-insensitive alphabetical order if multiple matches are found
   - eg, if “Ring World” and “Turing” exist as merchant names, “Ring World” would be returned, even if “Turing” was created first
- allow the user to specify a ‘name’ query parameter:
   - for merchants, the user can send ?name=ring and it will search the name field in the database table
-  parameter cannot be missing
- parameter cannot be empty